### PR TITLE
Update common.py

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -20,7 +20,7 @@ class CommonClient(object):
 
     def run_command(self, subcommand, args, success_code=0, 
                     return_stderr=False, combine=False, return_binary=False):
-        cmd = ['svn', subcommand] + args
+        cmd = ['svn', '--non-interactive', subcommand] + args
 
         _logger.debug("RUN: %s" % (cmd,))
 


### PR DESCRIPTION
SVN in interactive-mode is problematic, it can hang waiting for `stdin`, eg: if the certificate isn't known it will prompt to accept or reject. (took some time to debug this)

Better run in non-interactive mode so the prompt turns into an exception.
