### PR TITLE
Fix for CommonClient.info()

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -77,6 +77,8 @@ class CommonClient(object):
                     ['--xml', self.__url_or_path], 
                     combine=True)
 
+        begin = str(result).find('<?xml')
+        result = result[begin:]
         root = xml.etree.ElementTree.fromstring(result)
 
         entry_attr = root.find('entry').attrib


### PR DESCRIPTION
Fix for problem under Windows and cygwin, where the run_command returned some lines before the xml start. Could also be implemented there.