### PR TITLE
Log Messages by Revision Number Range

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -159,7 +159,8 @@ class CommonClient(object):
                 return_binary=True)
 
     def log_default(self, timestamp_from_dt=None, timestamp_to_dt=None, 
-                    limit=None, rel_filepath=None, stop_on_copy=False):
+                    limit=None, rel_filepath=None, stop_on_copy=False,
+                    revision_from=None, revision_to=None):
         """Allow for the most-likely kind of log listing: the complete list, a 
         FROM and TO timestamp, a FROM timestamp only, or a quantity limit.
         """
@@ -187,6 +188,19 @@ class CommonClient(object):
                 timestamp_to_phrase = 'HEAD'
 
             args += ['-r', timestamp_from_phrase + ':' + timestamp_to_phrase]
+
+        if revision_from or revision_to:
+            if timestamp_from_phrase or timestamp_to_phrase:
+                raise ValueError("The default log retriever can not take both "
+                                 "timestamp and revision number ranges.")
+
+            if not revision_from:
+                revision_from = '1'
+
+            if not revision_to:
+                revision_to = 'HEAD'
+
+            args += ['-r', str(revision_from) + ':' + str(revision_to)]
 
         if limit is not None:
             args += ['-l', str(limit)]

--- a/svn/resources/README.rst
+++ b/svn/resources/README.rst
@@ -109,10 +109,10 @@ Get file-data as string::
     l = svn.local.LocalClient('/tmp/test_repo')
     content = l.cat('test_file')
 
-log_default(timestamp_from_dt=None, timestamp_to_dt=None, limit=None, rel_filepath='', stop_on_copy=False)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+log_default(timestamp_from_dt=None, timestamp_to_dt=None, limit=None, rel_filepath='', stop_on_copy=False, revision_from=None, revision_to=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Perform a log-listing that can be bounded by time and/or take a maximum-
+Perform a log-listing that can be bounded by time or revision number and/or take a maximum-
 count::
 
     import svn.local


### PR DESCRIPTION
This will allow the log messages that are returned by log_default,
to be bound by the revision number. If the new arguments are not provided,
the function behaves normally.