### PR TITLE
Query svn properties

### DIFF
--- a/dev/test.py
+++ b/dev/test.py
@@ -49,6 +49,8 @@ import pprint
 l = svn.local.LocalClient('/tmp/test_repo.co')
 info = l.info()
 pprint.pprint(info)
+properties = l.properties()
+pprint.pprint(properties)
 
 sys.exit(0)
 

--- a/svn/common.py
+++ b/svn/common.py
@@ -157,6 +157,44 @@ class CommonClient(object):
 
         return info
 
+    def properties(self, rel_path=None):
+        """ Return a dictionary with all svn-properties associated with a relative path
+        :param rel_path: relative path in the svn repo to query the properties from
+        :returns: a dictionary with the property name as key and the content as value 
+        """
+
+        full_url_or_path = self.__url_or_path
+        if rel_path is not None:
+            full_url_or_path += '/' + rel_path
+
+        property_list = []
+
+        result = self.run_command(
+                    'proplist', 
+                    ['--xml', full_url_or_path], 
+                    combine=True)
+
+        # query the proper list of this path
+        root = xml.etree.ElementTree.fromstring(result)
+        target_elem = root.find('target')
+        property_names = [ p.attrib["name"] for p in target_elem.findall('property')]
+
+        # now query the content of each propery
+        property_dict = {}
+
+        for property_name in property_names:
+            result = self.run_command(
+                        'propget', 
+                        ['--xml', '{0}'.format(property_name), full_url_or_path, ], 
+                        combine=True)
+            root = xml.etree.ElementTree.fromstring(result)
+            target_elem = root.find('target')
+            property_elem = target_elem.find('property')
+            property_dict[property_name] = property_elem.text
+        
+        return property_dict
+
+
     def cat(self, rel_filepath, revision=None):
         cmd = []                 
         if revision is not None: 


### PR DESCRIPTION
This pull request adds the properties() method to the CommonClient class. It allows to query the subversion properties for any reference within the repository. The properties are parsed and returned as a dictionary.