### PR TITLE
Allow newer versions of python-dateutil

### DIFF
--- a/svn/resources/requirements.txt
+++ b/svn/resources/requirements.txt
@@ -1,1 +1,1 @@
-python-dateutil==2.2
+python-dateutil>=2.2


### PR DESCRIPTION
Allow newer versions of python-dateutil (>=2.2)