### PR TITLE
Raise SvnCommandError when the SVN CLI command returns an error code.

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -10,6 +10,14 @@ import svn.constants
 _logger = logging.getLogger('svn')
 
 
+class SvnCommandError(ValueError):
+    """Raised when the SVN CLI command returns an error code.
+
+    Subclass of ValuError for backward compatibility.
+    """
+    pass
+
+
 class CommonClient(object):
 
     def __init__(self, url_or_path, type_, *args, **kwargs):
@@ -49,8 +57,8 @@ class CommonClient(object):
         r = p.wait()
 
         if r != success_code:
-            raise ValueError("Command failed with (%d): %s\n%s" %
-                             (p.returncode, cmd, stdout))
+            raise SvnCommandError("Command failed with ({}): {}\n{}}".format(
+                                  (p.returncode, cmd, stdout)))
 
         if return_binary is True:
             return stdout


### PR DESCRIPTION
This allows the caller to make a distinction between this specific error, or any other cause of a `ValueError`. This is especially important since `run_command()` is a generator, so the exception is going to be raised when iterating over the result (rather than at call time).

`SvnCommandError` is a subclass of `ValueError` in order to stay backward compatible with existing exception handlers.
