### PR TITLE
With LANG=es_CL.utf8 fail with UnicodeDecodeError

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -41,7 +41,8 @@ class CommonClient(object):
 
         p = subprocess.Popen(cmd, 
                              stdout=subprocess.PIPE, 
-                             stderr=subprocess.STDOUT)
+                             stderr=subprocess.STDOUT,
+                             env={'LANG': 'en_US.utf8'})
 
         stdout = p.stdout.read()
         r = p.wait()


### PR DESCRIPTION
This is one "svn info" (obfuscated) with LANG=en_CL.utf8, on my Fedora 23.

```
Ruta: /home/rcovarru/svn/***
Working Copy Root Path: /home/rcovarru/svn/***
URL: https://****/trunk
Relative URL: ^/trunk/
Raíz del repositorio: https://***
UUID del repositorio: 00000000-0000-0000-0000-000000000000
Revisión: 559097
Tipo de nodo: directorio
Agendado: normal
Autor del último cambio: rcovarru
Revisión del último cambio: 559092
Fecha de último cambio: 2016-08-17 10:05:31 -0300 (mié 17 de ago de 2016)
```

Un svn info fail with:

```
  File "/home/rcovarru/svn/***/venv/lib/python2.7/site-packages/svn/remote.py", line 20, in checkout
    self.run_command('checkout', cmd)
  File "/home/rcovarru/svn/***/venv/lib/python2.7/site-packages/svn/common.py", line 59, in run_command
    return stdout.decode().strip('\n').split('\n')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 4796: ordinal not in range(128)
```