### PR TITLE
Python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+
 install:
   - pip install -r svn/resources/requirements.txt
   - pip install coveralls

--- a/svn/common.py
+++ b/svn/common.py
@@ -438,7 +438,7 @@ class CommonClient(object):
              '--new', '{0}@{1}'.format(full_url_or_path, new)],
             combine=True)
         file_to_diff = {}
-        for non_empty_diff in filter(None, diff_result.split('Index: ')):
+        for non_empty_diff in filter(None, diff_result.decode('utf8').split('Index: ')):
             split_diff = non_empty_diff.split('==')
             file_to_diff[split_diff[0].strip().strip('/')] = split_diff[-1].strip('=').strip()
         diff_summaries = self.diff_summary(old, new, rel_path)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,7 +4,7 @@ import os
 import unittest
 import shutil
 
-from resources.expected_output import diff_summary, diff_summary_2, cat
+from tests.resources.expected_output import diff_summary, diff_summary_2, cat
 from svn.common import CommonClient, SvnException
 
 
@@ -63,7 +63,7 @@ class TestCommonClient(unittest.TestCase):
         :return:
         """
         actual_answer = CommonClient(self.test_svn_url, 'url').list()
-        self.assertEqual(actual_answer.next(), 'abdera/')
+        self.assertEqual(next(actual_answer), 'abdera/')
 
     def test_info(self):
         """
@@ -82,7 +82,7 @@ class TestCommonClient(unittest.TestCase):
         :return:
         """
         actual_answer = CommonClient(self.test_svn_url, 'url').log_default(revision_from=1761404, revision_to=1761403)
-        self.assertEqual(actual_answer.next().author, 'sseifert')
+        self.assertEqual(next(actual_answer).author, 'sseifert')
 
     def test_cat(self):
         """
@@ -90,7 +90,7 @@ class TestCommonClient(unittest.TestCase):
         :return:
         """
         actual_answer = CommonClient(self.test_svn_url, 'url').cat('abdera/abdera2/README', revision=1761404)
-        self.assertEqual(cat, actual_answer)
+        self.assertEqual(cat, actual_answer.decode())
 
     def test_export(self):
         """


### PR DESCRIPTION
Making all tests running successfully for python3 and adding it in `.travis.yml`