### PR TITLE
Build universal wheels, fixed "ResourceWarning: unclosed file" in tests for python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ venv*
 *.svn
 *.idea
 .coverage
+.tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setuptools.setup(
                 'resources/requirements.txt'],
     },
     install_requires=install_requires,
+    test_suite='tests',
 )

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,4 @@ setuptools.setup(
                 'resources/requirements.txt'],
     },
     install_requires=install_requires,
-    test_suite='tests',
 )

--- a/svn/common.py
+++ b/svn/common.py
@@ -54,8 +54,9 @@ class CommonClient(object):
                              stderr=subprocess.STDOUT,
                              env={'LANG': 'en_US.UTF-8'})
 
-        stdout = p.stdout.read()
         r = p.wait()
+        stdout = p.stdout.read()
+        p.stdout.close()
 
         if r != success_code:
             raise SvnException("Command failed with (%s): %s\n%s".format(

--- a/svn/common.py
+++ b/svn/common.py
@@ -54,8 +54,8 @@ class CommonClient(object):
                              stderr=subprocess.STDOUT,
                              env={'LANG': 'en_US.UTF-8'})
 
-        r = p.wait()
         stdout = p.stdout.read()
+        r = p.wait()
         p.stdout.close()
 
         if r != success_code:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27, py34, py35
+
+[testenv]
+commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,5 @@
 envlist = py27, py34, py35
 
 [testenv]
-commands = python setup.py test
+deps = nose
+commands = nosetests

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 envlist = py27, py34, py35
 
 [testenv]
-deps = nose
+deps = -rrequirements.txt
 commands = nosetests


### PR DESCRIPTION
Here I added ``setup.cfg`` to build universal wheels, ``tox.ini`` to test with tox and fixed ``ResourceWarning: unclosed file`` in tests with python3.

About the latter: I've seen a lot of ``.../svn/common.py:109: ResourceWarning: unclosed file <_io.BufferedReader name=5>`` warnings during test runs with python3.4 and python3.5, they all regard to not closed ``p.stdout``, so line added to close it.
