### PR TITLE
svn subprocess environment customization

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -22,32 +22,13 @@ class SvnException(Exception):
 
 
 class CommonClient(object):
-    """Subversion client
-
-    Parameters
-    ----------
-    url_or_path : str
-        Repository URL or path
-    type_ : str
-        One of ``svn.constants.LT_URL`` or ``svn.constants.LT_PATH``
-    username : str, optional
-        User name to use
-    password : str, optional
-        Password to use
-    svn_filepath : str, optional
-        Path to svn command
-    trust_cert : bool, optional
-        If client should trust server certificate for unknown authority
-    env : dict, optional
-        Environment variables added to ``svn`` process environment
-    """
     def __init__(self, url_or_path, type_, *args, **kwargs):
         self.__url_or_path = url_or_path
         self.__username = kwargs.pop('username', None)
         self.__password = kwargs.pop('password', None)
         self.__svn_filepath = kwargs.pop('svn_filepath', 'svn')
         self.__trust_cert = kwargs.pop('trust_cert', None)
-        self._env = kwargs.get('env', {})
+        self.__env = kwargs.get('env', {})
 
         if type_ not in (svn.constants.LT_URL, svn.constants.LT_PATH):
             raise SvnException("Type is invalid: %s" % type_)
@@ -73,7 +54,7 @@ class CommonClient(object):
 
         environment_variables = os.environ.copy()
         environment_variables['LANG'] = 'en_US.UTF-8'
-        environment_variables.update(self._env)
+        environment_variables.update(self.__env)
 
         p = subprocess.Popen(cmd,
                              stdout=subprocess.PIPE,

--- a/svn/common.py
+++ b/svn/common.py
@@ -53,8 +53,8 @@ class CommonClient(object):
         _logger.debug("RUN: %s" % (cmd,))
 
         environment_variables = os.environ.copy()
-        environment_variables['LANG'] = 'en_US.UTF-8'
         environment_variables.update(self.__env)
+        environment_variables['LANG'] = 'en_US.UTF-8'
 
         p = subprocess.Popen(cmd,
                              stdout=subprocess.PIPE,

--- a/svn/common.py
+++ b/svn/common.py
@@ -22,12 +22,32 @@ class SvnException(Exception):
 
 
 class CommonClient(object):
+    """Subversion client
+
+    Parameters
+    ----------
+    url_or_path : str
+        Repository URL or path
+    type_ : str
+        One of ``svn.constants.LT_URL`` or ``svn.constants.LT_PATH``
+    username : str, optional
+        User name to use
+    password : str, optional
+        Password to use
+    svn_filepath : str, optional
+        Path to svn command
+    trust_cert : bool, optional
+        If client should trust server certificate for unknown authority
+    env : dict, optional
+        Environment variables added to ``svn`` process environment
+    """
     def __init__(self, url_or_path, type_, *args, **kwargs):
         self.__url_or_path = url_or_path
         self.__username = kwargs.pop('username', None)
         self.__password = kwargs.pop('password', None)
         self.__svn_filepath = kwargs.pop('svn_filepath', 'svn')
         self.__trust_cert = kwargs.pop('trust_cert', None)
+        self._env = kwargs.get('env', {})
 
         if type_ not in (svn.constants.LT_URL, svn.constants.LT_PATH):
             raise SvnException("Type is invalid: %s" % type_)
@@ -53,6 +73,7 @@ class CommonClient(object):
 
         environment_variables = os.environ.copy()
         environment_variables['LANG'] = 'en_US.UTF-8'
+        environment_variables.update(self._env)
 
         p = subprocess.Popen(cmd,
                              stdout=subprocess.PIPE,


### PR DESCRIPTION
Here I've added possibility to pass custom set of environment variables to underlying ``svn`` command. Sometimes it's desirable to customize environment at use time but not desirable or possible to change global environment. For example my use case is setting ``SVN_SSH`` to use login not matching current user and ssh identity located at non-standard path.