### PR TITLE
fixing a bug in update

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -23,7 +23,7 @@ _STATUS_ENTRY = \
 
 
 class CommonClient(svn.common_base.CommonBase):
-    def __init__(self, url_or_path, type_, username=None, password=None, 
+    def __init__(self, url_or_path, type_, username=None, password=None,
                  svn_filepath='svn', trust_cert=None, env={}, *args, **kwargs):
         super(CommonClient, self).__init__(*args, **kwargs)
 
@@ -49,8 +49,10 @@ class CommonClient(svn.common_base.CommonBase):
             cmd += ['--username', self.__username]
             cmd += ['--password', self.__password]
             cmd += ['--no-auth-cache']
-
-        cmd += [subcommand] + args
+        if type(args) is list:
+            cmd += [subcommand] + args
+        else:
+            cmd += [subcommand] + [args]
         return self.external_command(cmd, environment=self.__env, **kwargs)
 
     def __element_text(self, element):
@@ -301,7 +303,7 @@ class CommonClient(svn.common_base.CommonBase):
             change_type_raw = wcstatus_attr['item']
             change_type = svn.constants.STATUS_TYPE_LOOKUP[change_type_raw]
 
-            # This will be absent if the file is "unversioned". It'll be "-1" 
+            # This will be absent if the file is "unversioned". It'll be "-1"
             # if added but not committed.
             revision = wcstatus_attr.get('revision')
             if revision is not None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -266,14 +266,6 @@ class TestCommonClient(unittest.TestCase):
         actual_answer = cc.cat('abdera/abdera2/README', revision=1761404)
         self.assertEqual(cat, actual_answer.decode())
 
-    def test_update(self):
-        """
-        Checking update
-        :return:
-        """
-        cc = self.__get_cc()
-        cc.update('.')
-
     def test_export(self):
         """
         Checking export

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,7 +17,7 @@ import svn.admin
 
 _LOGGER = logging.getLogger(__name__)
 
-# TODO(dustin): Refactor to build and use an adhoc SVN repository for the 
+# TODO(dustin): Refactor to build and use an adhoc SVN repository for the
 #               tests.
 
 
@@ -232,19 +232,19 @@ class TestCommonClient(unittest.TestCase):
         actual_answer = cc.info()
 
         self.assertEqual(
-            actual_answer['entry_path'], 
+            actual_answer['entry_path'],
             'asf')
-        
+
         self.assertEqual(
-            actual_answer['repository_root'], 
+            actual_answer['repository_root'],
             'http://svn.apache.org/repos/asf')
-        
+
         self.assertEqual(
-            actual_answer['entry#kind'], 
+            actual_answer['entry#kind'],
             'dir')
-        
+
         self.assertEqual(
-            actual_answer['repository/uuid'], 
+            actual_answer['repository/uuid'],
             '13f79535-47bb-0310-9956-ffa450edef68')
 
     def test_log(self):
@@ -266,6 +266,14 @@ class TestCommonClient(unittest.TestCase):
         actual_answer = cc.cat('abdera/abdera2/README', revision=1761404)
         self.assertEqual(cat, actual_answer.decode())
 
+    def test_update(self):
+        """
+        Checking cat
+        :return:
+        """
+        cc = self.__get_cc()
+        cc.update('.')
+
     def test_export(self):
         """
         Checking export
@@ -273,7 +281,7 @@ class TestCommonClient(unittest.TestCase):
         """
         cc = \
             svn.common.CommonClient(
-                'http://svn.apache.org/repos/asf/tcl/websh/trunk/', 
+                'http://svn.apache.org/repos/asf/tcl/websh/trunk/',
                 'url')
 
         cc.export(to_path='CHANGES', revision=1761404)
@@ -292,7 +300,7 @@ class TestCommonClient(unittest.TestCase):
             cc.export(to_path='CHANGES', revision=1761404)
         try:
             cc.export(to_path='CHANGES', revision=1761404, force=True)
-# TODO(dustin): This except probably unnecessary (any exception should likely 
+# TODO(dustin): This except probably unnecessary (any exception should likely
 #               trigger failure).
         except svn.exception.SvnException:
             self.fail("SvnException raised with force export")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -268,7 +268,7 @@ class TestCommonClient(unittest.TestCase):
 
     def test_update(self):
         """
-        Checking cat
+        Checking update
         :return:
         """
         cc = self.__get_cc()


### PR DESCRIPTION
if `args` in `update()` is a plain string, then it cannot be concatenated to a list.  This causes an error, and extra logic for placing `args` in a list is needed.