### PR TITLE
Added the ability to query individual properties, and to do so recursively

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -135,6 +135,47 @@ class CommonClient(svn.common_base.CommonBase):
         info['commit_revision'] = info['commit#revision']
 
         return info
+		
+    def get_property(self, property, rel_path=None, revision=None, recursive=False):
+        """ Return an svn property, or, if called recursively, a list of tuples associated with a
+                    relative path.
+                :param property: the property to query
+                :param rel_path: relative path in the svn repo to query the
+                                 property from
+                :param revision: the revision to query the property from
+                :param recursive: flag for recursivity
+                :returns: if recursive, a list of pairs (svn path, property value)
+                otherwise, a single str corresponding to the property value
+		"""
+        args = []
+        if recursive == True:
+            args += ['-R']
+        if revision:
+            args += ['-r', str(revision)]
+
+        full_url_or_path = self.__url_or_path
+        if rel_path is not None:
+            full_url_or_path += '/' + rel_path
+
+        result = self.run_command(
+            'propget',
+            args + ['--xml', property, full_url_or_path],
+            do_combine=True)
+        root = xml.etree.ElementTree.fromstring(result)
+
+        if recursive == True:
+            # This will return a list of tuples
+            to_return = []
+            for target_elem in root.findall('target'):
+                key = target_elem.get('path')
+                value = target_elem.find('property').text
+                to_return += [(key, value)]
+        else:
+            # This will return a single value
+            target_elem = root.find('target')
+            property_elem = target_elem.find('property')
+            to_return = property_elem.text
+        return to_return
 
     def properties(self, rel_path=None):
         """ Return a dictionary with all svn-properties associated with a
@@ -164,14 +205,7 @@ class CommonClient(svn.common_base.CommonBase):
         property_dict = {}
 
         for property_name in property_names:
-            result = self.run_command(
-                'propget',
-                ['--xml', property_name, full_url_or_path, ],
-                do_combine=True)
-            root = xml.etree.ElementTree.fromstring(result)
-            target_elem = root.find('target')
-            property_elem = target_elem.find('property')
-            property_dict[property_name] = property_elem.text
+            property_dict[property_name] = self.get_property(property_name, rel_path)
 
         return property_dict
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -143,6 +143,24 @@ class TestCommonClient(unittest.TestCase):
 
         self.__temp_lc.add(rel_filepath)
 
+    def test_get_property(self):
+        cc = self.__get_cc()
+        actual_answer = cc.get_property('svn:ignore', rel_path='whirr/tags/release-0.7.0/services/voldemort', recursive=True)
+        
+        self.assertListEqual(actual_answer, [(
+            'http://svn.apache.org/repos/asf/whirr/tags/release-0.7.0/services/voldemort',
+            '\n'.join(['.project', '.classpath', '.settings', 'target', '', ''])
+        ), (
+            'http://svn.apache.org/repos/asf/whirr/tags/release-0.7.0/services/voldemort/lib',
+            'linkedin-voldemort-0.90.RC3.jar\n'
+        )])
+
+    def test_properties(self):
+        cc = self.__get_cc()
+        actual_answer = cc.properties(rel_path='whirr/tags/release-0.7.0/services/zookeeper')
+        
+        self.assertDictEqual(actual_answer, {'svn:ignore': '\n'.join(['.project', '.classpath', '.settings', 'target', ''])})
+		
     def test_status(self):
         self.__stage_co_directory_1()
 


### PR DESCRIPTION
Like I said before, I'm not a giant fan of the way that this works.

My issues with this commit

1) Repeated code for treating rel_path
2) Multiple return types from get_property (string if not recursive, list of tuples if recursive)
* As an aside here, it might be more consistent if get_property called with recursive=False returned a list with 1 element, but I don't like that either because now you're returning superfluous information for the sake of a consistent return type.*

It might be nicer to put this in the properties() method instead, but then it becomes a misnomer (querying properties for one property) and I still can't find a good solution to the multiple return types.

Also, thanks for the hints about squashing commits.
