### PR TITLE
Removed unused svnadmin_filepath from Admin.create.

### DIFF
--- a/svn/admin.py
+++ b/svn/admin.py
@@ -15,14 +15,11 @@ class Admin(svn.common_base.CommonBase):
         self.__env = env
         self.__svnadmin_filepath = svnadmin_filepath
 
-    def create(self, path, svnadmin_filepath=None):
-        return self.__run_command(svnadmin_filepath, 'create', [path],
-                                  do_combine=True)
+    def create(self, path):
+        return self.__run_command('create', [path], do_combine=True)
 
-    def __run_command(self, svnadmin_filepath, subcommand, args, **kwargs):
-        cmd = [self.__svnadmin_filepath
-               if svnadmin_filepath is None
-               else svnadmin_filepath]
+    def __run_command(self, subcommand, args, **kwargs):
+        cmd = [self.__svnadmin_filepath]
 
         cmd += [subcommand] + args
         return self.external_command(cmd, environment=self.__env, **kwargs)

--- a/svn/admin.py
+++ b/svn/admin.py
@@ -15,11 +15,14 @@ class Admin(svn.common_base.CommonBase):
         self.__env = env
         self.__svnadmin_filepath = svnadmin_filepath
 
-    def create(self, path, svnadmin_filepath='svnadmin'):
-        return self.__run_command('create', [path], do_combine=True)
+    def create(self, path, svnadmin_filepath=None):
+        return self.__run_command(svnadmin_filepath, 'create', [path],
+                                  do_combine=True)
 
-    def __run_command(self, subcommand, args, **kwargs):
-        cmd = [self.__svnadmin_filepath]
+    def __run_command(self, svnadmin_filepath, subcommand, args, **kwargs):
+        cmd = [self.__svnadmin_filepath
+               if svnadmin_filepath is None
+               else svnadmin_filepath]
 
         cmd += [subcommand] + args
         return self.external_command(cmd, environment=self.__env, **kwargs)


### PR DESCRIPTION
I removed the svnadmin_filepath. It was unused, and I first thought to fix that. I then decided to rather remove it. I based this though on the Zen of Python statement: There should be one-- and preferably only one --obvious way to do it. The svnadmin file path can already be specified in the Admin class constructor, and I do not see why it would be useful to do this via the Admin methods as well.