### PR TITLE
Updated Status to Include Changelists

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -301,6 +301,7 @@ class CommonClient(svn.common_base.CommonBase):
         root = xml.etree.ElementTree.fromstring(raw)
 
         list_ = root.findall('target/entry')
+        list_ += root.findall('changelist/entry')
         for entry in list_:
             entry_attr = entry.attrib
             name = entry_attr['path']

--- a/svn/common.py
+++ b/svn/common.py
@@ -288,7 +288,7 @@ class CommonClient(svn.common_base.CommonBase):
 
         self.run_command('export', cmd)
 
-    def status(self, rel_path=None):
+    def status(self, rel_path=None, single_changelist=None):
         full_url_or_path = self.__url_or_path
         if rel_path is not None:
             full_url_or_path += '/' + rel_path
@@ -301,7 +301,11 @@ class CommonClient(svn.common_base.CommonBase):
         root = xml.etree.ElementTree.fromstring(raw)
 
         list_ = root.findall('target/entry')
-        list_ += root.findall('changelist/entry')
+        changelists = root.findall('changelist')
+        for changelist in changelists:
+            if (single_changelist and single_changelist == changelist.attrib['name']) \
+                    or changelist.attrib['name'] != 'ignore-on-commit':
+                list_ += changelist.findall('entry')
         for entry in list_:
             entry_attr = entry.attrib
             name = entry_attr['path']


### PR DESCRIPTION
The status command would ignore all files contained on a change-list. This change allows all files not on the ignore list to be displayed by status.