### PR TITLE
fixes url for `list_recursive` on win in remote

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "c:\\Users\\TGubs\\Code\\Python\\PySvn\\venv\\Scripts\\python.exe"
+}

--- a/svn/remote.py
+++ b/svn/remote.py
@@ -1,3 +1,6 @@
+
+import posixpath
+
 import svn.constants
 import svn.common
 
@@ -21,3 +24,34 @@ class RemoteClient(svn.common.CommonClient):
 
     def __repr__(self):
         return '<SVN(REMOTE) %s>' % self.url
+
+    def list_recursive(self, rel_path=None, yield_dirs=False,
+                       path_filter_cb=None):
+        q = [rel_path]
+        while q:
+            current_rel_path = q[0]
+            del q[0]
+
+            for entry in self.list(extended=True, rel_path=current_rel_path):
+                if entry['is_directory'] is True:
+                    if current_rel_path is not None:
+                        next_rel_path = \
+                            posixpath.join(current_rel_path, entry['name'])
+                    else:
+                        next_rel_path = entry['name']
+
+                    do_queue = True
+                    if path_filter_cb is not None:
+                        result = path_filter_cb(next_rel_path)
+                        if result is False:
+                            do_queue = False
+
+                    if do_queue is True:
+                        q.append(next_rel_path)
+
+                if entry['is_directory'] is False or yield_dirs is True:
+                    current_rel_path_phrase = current_rel_path \
+                        if current_rel_path is not None \
+                        else ''
+
+                    yield (current_rel_path_phrase, entry)


### PR DESCRIPTION
- remote client used to make bad urls on windows
- due to os.path.join, urls contained backslash-escaped chars
- now remotes use posixpath.join, which is safe for urls

This addresses issues found in #139 