### PR TITLE
Cleanup and resubmit several PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ venv*
 .tox
 /pip-selfcheck.json
 /man
+.eggs

--- a/svn/common.py
+++ b/svn/common.py
@@ -328,7 +328,7 @@ class CommonClient(svn.common_base.CommonBase):
             }
             yield info
 
-    def status(self, rel_path=None):
+    def status(self, rel_path=None, include_changelists=False):
         full_url_or_path = self.__url_or_path
         if rel_path is not None:
             full_url_or_path += '/' + rel_path
@@ -341,6 +341,9 @@ class CommonClient(svn.common_base.CommonBase):
         root = xml.etree.ElementTree.fromstring(raw)
 
         list_ = root.findall('target/entry')
+        if include_changelists is True:
+            list_ += root.findall('changelist/entry')
+
         for entry in list_:
             entry_attr = entry.attrib
             name = entry_attr['path']

--- a/svn/common.py
+++ b/svn/common.py
@@ -332,14 +332,18 @@ class CommonClient(svn.common_base.CommonBase):
             }
             yield info
 
-    def status(self, rel_path=None, include_changelists=False):
+    def status(self, rel_path=None, no_ignore=False, include_changelists=False):
         full_url_or_path = self.__url_or_path
         if rel_path is not None:
             full_url_or_path += '/' + rel_path
 
+        cmd = ['--xml', full_url_or_path]
+        if no_ignore:
+            cmd.append('--no-ignore')
+
         raw = self.run_command(
             'status',
-            ['--xml', full_url_or_path],
+            cmd,
             do_combine=True)
 
         root = xml.etree.ElementTree.fromstring(raw)

--- a/svn/common.py
+++ b/svn/common.py
@@ -20,6 +20,9 @@ _STATUS_ENTRY = \
             'type',
             'revision',
         ])
+LOG_ENTRY = collections.namedtuple(
+    'LogEntry',
+    ('date', 'msg', 'revision', 'author', 'changelist'))
 
 
 class CommonClient(svn.common_base.CommonBase):
@@ -248,10 +251,6 @@ class CommonClient(svn.common_base.CommonBase):
             do_combine=True)
 
         root = xml.etree.ElementTree.fromstring(result)
-        named_fields = ['date', 'msg', 'revision', 'author', 'changelist']
-        c = collections.namedtuple(
-            'LogEntry',
-            named_fields)
 
         # Merge history can create nested log entries, so use iter instead of findall
         for e in root.iter('logentry'):
@@ -278,7 +277,7 @@ class CommonClient(svn.common_base.CommonBase):
             else:
                 log_entry['changelist'] = None
 
-            yield c(**log_entry)
+            yield LOG_ENTRY(**log_entry)
 
     def export(self, to_path, revision=None, force=False):
         cmd = []

--- a/svn/common.py
+++ b/svn/common.py
@@ -160,6 +160,11 @@ class CommonClient(svn.common_base.CommonBase):
         # query the proper list of this path
         root = xml.etree.ElementTree.fromstring(result)
         target_elem = root.find('target')
+
+        # check for empty property list
+        if target_elem is None:
+            return {}
+
         property_names = [p.attrib["name"]
                           for p in target_elem.findall('property')]
 

--- a/svn/common.py
+++ b/svn/common.py
@@ -287,6 +287,43 @@ class CommonClient(svn.common_base.CommonBase):
         cmd.append('--force') if force else None
 
         self.run_command('export', cmd)
+    
+    def blame(self, rel_filepath, 
+            revision_from=None, revision_to=None):
+        """
+        svn usage: blame [-r M:N] TARGET[@REV]
+        """
+
+        full_url_or_path = self.__url_or_path + "/" + rel_filepath
+        
+        args = []
+        if revision_from or revision_to:
+            if not revision_from:
+                revision_from = '1'
+
+            if not revision_to:
+                revision_to = 'HEAD'
+
+            args += ['-r', str(revision_from) + ':' + str(revision_to)]
+
+        result = self.run_command(
+            "blame", args + ["--xml", full_url_or_path], do_combine=True)
+        
+        root = xml.etree.ElementTree.fromstring(result)
+
+        for entry in root.findall("target/entry"):
+            commit = entry.find("commit")
+            author = entry.find("commit/author")
+            date_ = entry.find("commit/date")
+            if author is None or date_ is None:
+                continue
+            info = {
+                'line_number': int(entry.attrib['line-number']),
+                "commit_author": self.__element_text(author),
+                "commit_date": dateutil.parser.parse(date_.text),
+                "commit_revision": int(commit.attrib["revision"]),
+            }
+            yield info
 
     def status(self, rel_path=None):
         full_url_or_path = self.__url_or_path

--- a/svn/common.py
+++ b/svn/common.py
@@ -185,7 +185,7 @@ class CommonClient(svn.common_base.CommonBase):
     def log_default(self, timestamp_from_dt=None, timestamp_to_dt=None,
                     limit=None, rel_filepath=None, stop_on_copy=False,
                     revision_from=None, revision_to=None, changelist=False,
-                    use_merge_history=False):
+                    use_merge_history=False, search=None):
         """Allow for the most-likely kind of log listing: the complete list,
         a FROM and TO timestamp, a FROM timestamp only, or a quantity limit.
         """
@@ -232,6 +232,9 @@ class CommonClient(svn.common_base.CommonBase):
 
         if stop_on_copy is True:
             args += ['--stop-on-copy']
+
+        if search is not None:
+            args += ['--search', search]
 
         if use_merge_history is True:
             args += ['--use-merge-history']

--- a/svn/common.py
+++ b/svn/common.py
@@ -505,13 +505,36 @@ class CommonClient(svn.common_base.CommonBase):
              '--new', '{0}@{1}'.format(full_url_or_path, new)],
             do_combine=True)
         file_to_diff = {}
+
+        # A diff has this form, potentially repeating for multiple files.
+        #
+        #  Index: relative/filename.txt
+        # ===================================================================
+        # The diff content
+        #
+        # Here we split diffs into files by the index section, pick up the
+        # file name, then split again to pick up the content.
         for non_empty_diff in filter(None, diff_result.decode('utf8').split('Index: ')):
-            split_diff = non_empty_diff.split('==')
-            file_to_diff[split_diff[0].strip().strip('/')] = split_diff[-1].strip('=').strip()
+            split_diff = non_empty_diff.split('='*67)
+            index_filename = split_diff[0].strip().strip('/')
+            file_to_diff[index_filename] = split_diff[-1].strip()
         diff_summaries = self.diff_summary(old, new, rel_path)
+
+        # Allocate summary info to the text for each change.
+        # Not all diffs necessarily affect file text (directory changes, for example).
         for diff_summary in diff_summaries:
-            diff_summary['diff'] = \
-                file_to_diff[diff_summary['path'].split(full_url_or_path)[-1].strip('/')]
+            diff_summary['diff'] = ''
+            if 'path' in diff_summary:
+                # Summary file paths are absolute, while diff file indexes are relative.
+                # We try to match them up, first checking the root of the diff.
+                summary_index = diff_summary['path'][len(full_url_or_path):].strip('/')
+                # If the diff was conducted directly on the file, not a directory, the
+                # above will fail to find the relative file name, so we look for that directly.
+                if summary_index == '':
+                    summary_index = os.path.basename(full_url_or_path)
+                # If we can match a diff to a summary, we attach it.
+                if summary_index in file_to_diff:
+                    diff_summary['diff'] = file_to_diff[summary_index]
         return diff_summaries
 
     @property

--- a/svn/common_base.py
+++ b/svn/common_base.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import subprocess
 import logging
 
@@ -17,13 +18,22 @@ class CommonBase(object):
         env['LANG'] = svn.config.CONSOLE_ENCODING
         env.update(environment)
 
-        p = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            cwd=wd,
-            env=env)
+        kwargs = {
+            'stdout': subprocess.PIPE,
+            'stderr': subprocess.STDOUT,
+            'cwd': wd,
+            'env': env,
+        }
 
+        try:
+            # Don't open Command Prompt on Windows
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            kwargs['startupinfo'] = startupinfo
+        except AttributeError:
+            pass
+
+        p = subprocess.Popen(cmd, **kwargs)
         stdout = p.stdout.read()
         r = p.wait()
         p.stdout.close()

--- a/svn/common_base.py
+++ b/svn/common_base.py
@@ -13,6 +13,7 @@ class CommonBase(object):
     def external_command(self, cmd, success_code=0, do_combine=False, 
                          return_binary=False, environment={}, wd=None):
         _LOGGER.debug("RUN: %s" % (cmd,))
+        # print("RUN:", cmd)
 
         env = os.environ.copy()
         env['LANG'] = svn.config.CONSOLE_ENCODING

--- a/svn/local.py
+++ b/svn/local.py
@@ -46,3 +46,13 @@ class LocalClient(svn.common.CommonClient):
             'cleanup',
             [],
             wd=self.path)
+
+    def propset(self, property_name, property_value, rel_path=None):
+        '''Set a property on a relative path'''
+        if rel_path is None:
+            rel_path = '.'
+            
+        self.run_command(
+            'propset',
+            [property_name, property_value, rel_path],
+            wd=self.path)

--- a/svn/resources/README.rst
+++ b/svn/resources/README.rst
@@ -25,6 +25,7 @@ Functions currently implemented:
 - commit
 - update
 - cleanup
+- blame
 
 In addition, there is also an "admin" class (`svn.admin.Admin`) that provides a `create` method with which to create repositories.
 
@@ -277,6 +278,24 @@ diff(start_revision,  end_revision)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Finds all the diff between start and end revision id. Here another key of 'diff' is added which shows the diff of files.
+
+blame(rel_filepath, revision=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Blame specified file ::
+
+    import svn.local
+
+    l = svn.local.LocalClient('/tmp/test_repo.co')
+    
+    for line_info in l.blame("version.py"):
+        print(line_info)
+
+        # {
+        #    'line_number': 1,
+        #    'commit_revision': 1222,
+        #    'commit_author': 'codeskyblue',
+        #    'commit_date': datetime.datetime(2018, 12, 20, 3, 25, 13, 479212, tzinfo=tzutc())}
 
 .. |Build_Status| image:: https://travis-ci.org/dsoprea/PySvn.svg?branch=master
    :target: https://travis-ci.org/dsoprea/PySvn

--- a/svn/resources/README.rst
+++ b/svn/resources/README.rst
@@ -20,6 +20,7 @@ Functions currently implemented:
 - cat
 - diff
 - diff_summary
+- propset
 - status
 - add
 - commit

--- a/svn/resources/README.rst
+++ b/svn/resources/README.rst
@@ -134,8 +134,8 @@ Get file-data as string::
     l = svn.local.LocalClient('/tmp/test_repo')
     content = l.cat('test_file')
 
-log_default(timestamp_from_dt=None, timestamp_to_dt=None, limit=None, rel_filepath='', stop_on_copy=False, revision_from=None, revision_to=None, changelist=False)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+log_default(timestamp_from_dt=None, timestamp_to_dt=None, limit=None, rel_filepath='', stop_on_copy=False, revision_from=None, revision_to=None, changelist=False, search=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Perform a log-listing that can be bounded by time or revision number and/or take a maximum-
 count::

--- a/svn/resources/README.rst
+++ b/svn/resources/README.rst
@@ -1,5 +1,3 @@
-|donate|
-
 |Build\_Status|
 |Coverage\_Status|
 
@@ -280,9 +278,6 @@ diff(start_revision,  end_revision)
 
 Finds all the diff between start and end revision id. Here another key of 'diff' is added which shows the diff of files.
 
-.. |donate| image:: https://pledgie.com/campaigns/31718.png?skin_name=chrome
-   :alt: Click here to lend your support to: PySvn and make a donation at pledgie.com !
-   :target: https://pledgie.com/campaigns/31718
 .. |Build_Status| image:: https://travis-ci.org/dsoprea/PySvn.svg?branch=master
    :target: https://travis-ci.org/dsoprea/PySvn
 .. |Coverage_Status| image:: https://coveralls.io/repos/github/dsoprea/PySvn/badge.svg?branch=master

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -35,7 +35,12 @@ class TestAdmin(unittest.TestCase):
             a.create(temp_path)
 
             # Do a read.
-            rc = svn.remote.RemoteClient('file://' + temp_path)
+            # Duck-type identification of path type (Windows, Linux, etc.) to ensure
+            # file uri canonicity is enforced. URI must be file:///.
+            if temp_path[0] == '/':
+                rc = svn.remote.RemoteClient('file://' + temp_path)
+            else:
+                rc = svn.remote.RemoteClient('file:///' + temp_path)
             info = rc.info()
             _LOGGER.debug("Info from new repository: [%s]", str(info))
         finally:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -57,7 +57,7 @@ class TestCommonClient(unittest.TestCase):
         self.__temp_co_path = self.__get_temp_path_to_use()
         _LOGGER.debug("CO_PATH: {}".format(self.__temp_co_path))
 
-        r = svn.remote.RemoteClient('file://' + self.__temp_repo_path)
+        r = svn.remote.RemoteClient('file:///' + self.__temp_repo_path)
         r.checkout(self.__temp_co_path)
 
         # Create a client for it.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -282,6 +282,17 @@ class TestCommonClient(unittest.TestCase):
             cc.log_default(revision_from=1761404, revision_to=1761403)
         self.assertEqual(next(actual_answer).author, 'sseifert')
 
+    def test_search(self):
+        """
+        Checking log search
+        :return:
+        """
+
+        cc = self.__get_cc()
+        actual_answer = \
+            cc.log_default(search='Get ready to tag httpd 2.4.34', revision_from=1835550, revision_to=1836000)
+        self.assertEqual(next(actual_answer).author, 'jim')
+
     def test_cat(self):
         """
         Checking cat

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -335,3 +335,33 @@ class TestCommonClient(unittest.TestCase):
 
     def test_cleanup(self):
         self.__temp_lc.cleanup()
+
+    def test_properties(self):  
+        '''Tests CommonClient.properties() and LocalClient.propset()'''
+        l = self.__temp_lc
+
+        # Test propset with rel_path omitted
+        self.assertTrue('prop1' not in l.properties())
+        l.propset('prop1', 'value1')
+        self.assertTrue('prop1' in l.properties() and
+                        l.properties()['prop1'] == 'value1')
+
+        # Add a file
+        filepath = os.path.join(self.__temp_co_path, 'propfile2')
+        with open(filepath, 'w') as f:
+            pass
+
+        l.add('propfile2')
+
+        # properties should be empty until we add some
+        self.assertTrue(l.properties(rel_path='propfile2') == {})
+
+        # Test with rel_path='propfile2'
+        self.assertTrue('prop2' not in l.properties(rel_path='propfile2'))
+        l.propset('prop2', 'value2', rel_path='propfile2')
+        self.assertTrue('prop2' in l.properties(rel_path='propfile2') and 
+                        l.properties(rel_path='propfile2')['prop2'] == 'value2')
+
+        # Cross-check
+        self.assertTrue('prop1' not in l.properties(rel_path='propfile2'))
+        self.assertTrue('prop2' not in l.properties())

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -257,7 +257,15 @@ class TestCommonClient(unittest.TestCase):
         self.assertEqual(
             actual_answer['repository/uuid'],
             '13f79535-47bb-0310-9956-ffa450edef68')
-
+    
+    def test_blame(self):
+        cc = self.__get_cc()
+        actual_answer = cc.blame('abdera/abdera2/README', revision_to=1173209)
+        ans = next(actual_answer)
+        self.assertEqual(ans['line_number'], 1)
+        self.assertEqual(ans['commit_revision'], 1173209)
+        self.assertEqual(ans['commit_author'], 'jmsnell')
+        
     def test_info_revision(self):
         cc = self.__get_cc()
         actual_answer = cc.info(revision=1000000)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -57,6 +57,8 @@ class TestCommonClient(unittest.TestCase):
         self.__temp_co_path = self.__get_temp_path_to_use()
         _LOGGER.debug("CO_PATH: {}".format(self.__temp_co_path))
 
+        # Duck-type identification of path type (Windows, Linux, etc.) to ensure
+        # file uri canonicity is enforced. URI must be file:///.
         if self.__temp_repo_path[0] == '/':
             r = svn.remote.RemoteClient('file://' + self.__temp_repo_path)
         else: 
@@ -265,6 +267,18 @@ class TestCommonClient(unittest.TestCase):
                         'http://svn.apache.org/repos/asf/sling/trunk/pom.xml' \
                             in individual_diff[diff_key])
 
+    def test_diff_separator(self):
+        """
+        Checking diff
+        :return:
+        """
+        cc = self.__get_cc()
+        change = '502054'
+        file_cluster_event = 'activemq/activecluster/trunk/src/main/java/org/apache/activecluster/ClusterEvent.java'
+        actual_answer = cc.diff('0', change, file_cluster_event)[0]
+        self.assertTrue('static final int UPDATE_NODE = 2' in actual_answer['diff'])
+        self.assertTrue('else if (type == FAILED_NODE)' in actual_answer['diff'])
+
     def test_list(self):
         """
         Checking list
@@ -375,6 +389,16 @@ class TestCommonClient(unittest.TestCase):
 
     def test_cleanup(self):
         self.__temp_lc.cleanup()
+
+    def test_properties_cc(self):
+        """
+        '''Tests CommonClient.properties()'''
+        """
+        cc = self.__get_cc()
+        props = cc.properties('activemq/activecluster/trunk/src/main/java/org/apache/activecluster@1808406')
+        self.assertFalse(bool(props))
+        props = cc.properties('activemq/activecluster/trunk/src/main/java/org/apache/activecluster/Cluster.java@1808406')
+        self.assertEqual(props['svn:eol-style'], 'native')
 
     def test_properties(self):  
         '''Tests CommonClient.properties() and LocalClient.propset()'''

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -57,7 +57,10 @@ class TestCommonClient(unittest.TestCase):
         self.__temp_co_path = self.__get_temp_path_to_use()
         _LOGGER.debug("CO_PATH: {}".format(self.__temp_co_path))
 
-        r = svn.remote.RemoteClient('file:///' + self.__temp_repo_path)
+        if self.__temp_repo_path[0] == '/':
+            r = svn.remote.RemoteClient('file://' + self.__temp_repo_path)
+        else: 
+            r = svn.remote.RemoteClient('file:///' + self.__temp_repo_path)
         r.checkout(self.__temp_co_path)
 
         # Create a client for it.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -400,6 +400,9 @@ class TestCommonClient(unittest.TestCase):
         props = cc.properties('activemq/activecluster/trunk/src/main/java/org/apache/activecluster/Cluster.java@1808406')
         self.assertEqual(props['svn:eol-style'], 'native')
 
+        actual_answer = cc.properties(rel_path='whirr/tags/release-0.7.0/services/zookeeper')
+        self.assertDictEqual(actual_answer, {'svn:ignore': '\n'.join(['.project', '.classpath', '.settings', 'target', ''])})
+
     def test_properties(self):  
         '''Tests CommonClient.properties() and LocalClient.propset()'''
         l = self.__temp_lc


### PR DESCRIPTION
This PR includes no novel commits. I've taken several of the most promising PRs
(especially those with tests or resolved feedback) and merged them all together. Some of them I've improved by applying your
review feedback.

* Adding search option to log_default along with test case -- #120
* added "remove" command -- #83 (auth documentation only)
* Added propset(); added no_ignore option to status(); fixed bug in properties() -- #121 (and add to readme)
* add svn blame support -- #131 (squashed and fixed test)
* svn status can now include changelists' items -- #133 (squash and remove irrelevant changes)
* Hide command prompt on Windows when running subprocess. -- #136 (squash)
* Improved diff and properties -- #99 (squash, trailing whitespace)

This PR serves partly as a way to get these PRs submitted, but also as way to share my effort in collecting fixes for myself.

All tests pass for me locally.

```bash
$ python3 -m unittest 
............../svn/common.py:262: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  entry_info = {x.tag: x.text for x in e.getchildren()}
..../svn/common.py:262: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  entry_info = {x.tag: x.text for x in e.getchildren()}
...../svn/common.py:262: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  entry_info = {x.tag: x.text for x in e.getchildren()}
.....
----------------------------------------------------------------------
Ran 25 tests in 55.991s

OK
```
