### PR TITLE
Fix DeprecationWarning in log_default

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -258,7 +258,7 @@ class CommonClient(svn.common_base.CommonBase):
 
         # Merge history can create nested log entries, so use iter instead of findall
         for e in root.iter('logentry'):
-            entry_info = {x.tag: x.text for x in e.getchildren()}
+            entry_info = {x.tag: x.text for x in e}
 
             date = None
             date_text = entry_info.get('date')


### PR DESCRIPTION
We were using a deprecated method of iterating over the children.

> DeprecationWarning: This method will be removed in future versions.
> Use 'list(elem)' or iteration over elem instead.

Test still passes.