### PR TITLE
Add changelist to status entries

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -8,8 +8,15 @@ import svn.test_support
 class TestLocalClient(unittest.TestCase):
     def test_status(self):
         with svn.test_support.temp_repo():
-            with svn.test_support.temp_checkout() as (_, lc):
+            with svn.test_support.temp_checkout() as (wc, lc):
                 svn.test_support.populate_bigger_file_changes1()
+
+                file_in_cl = 'file_in_cl'
+                with open(file_in_cl, 'w') as f:
+                    f.write("data")
+
+                lc.add(file_in_cl)
+                lc.run_command('changelist', ['test-cl', file_in_cl])
 
                 status = {}
                 for s in lc.status():
@@ -17,10 +24,19 @@ class TestLocalClient(unittest.TestCase):
                     status[filename] = s
 
                 added = status['added']
-                self.assertTrue(added is not None and added.type == svn.constants.ST_ADDED)
+                self.assertIsNotNone(added)
+                self.assertTrue(added.type, svn.constants.ST_ADDED)
+                self.assertEqual(added.changelist, None)
 
                 committed_deleted = status['committed_deleted']
-                self.assertTrue(committed_deleted is not None and committed_deleted.type == svn.constants.ST_MISSING)
+                self.assertIsNotNone(committed_deleted)
+                self.assertEqual(committed_deleted.type, svn.constants.ST_MISSING)
+                self.assertEqual(added.changelist, None)
+
+                in_cl = status[file_in_cl]
+                self.assertIsNotNone(in_cl)
+                self.assertEqual(in_cl.changelist, 'test-cl')
+
 
     def test_remove(self):
         with svn.test_support.temp_repo():


### PR DESCRIPTION
Fix files in changelists don't appear in status(). Add changelist
attribute to status() result.

Since `svn status` includes files in changelists, it makes sense for
status() to include them as well. Add a field to _STATUS_ENTRY for
changelist. Files without a changelist have changelist=None and
otherwise changelist is the name of the changelist.

Rework the status test to use assertIsNotNone and assertEqual to give
better error messages. Invalid filenames produce KeyError and are not
None, so checking for None wasn't really preventing errors.