### PR TITLE
Adding search option to log along with test case

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -182,7 +182,7 @@ class CommonClient(svn.common_base.CommonBase):
     def log_default(self, timestamp_from_dt=None, timestamp_to_dt=None,
                     limit=None, rel_filepath=None, stop_on_copy=False,
                     revision_from=None, revision_to=None, changelist=False,
-                    use_merge_history=False):
+                    use_merge_history=False, search=None):
         """Allow for the most-likely kind of log listing: the complete list,
         a FROM and TO timestamp, a FROM timestamp only, or a quantity limit.
         """
@@ -229,6 +229,9 @@ class CommonClient(svn.common_base.CommonBase):
 
         if stop_on_copy is True:
             args += ['--stop-on-copy']
+
+        if search is not None:
+            args += ['--search', search]
 
         if use_merge_history is True:
             args += ['--use-merge-history']

--- a/svn/resources/README.md
+++ b/svn/resources/README.md
@@ -138,7 +138,7 @@ content = l.cat('test_file')
 ```
 
 
-### log_default(timestamp_from_dt=None, timestamp_to_dt=None, limit=None, rel_filepath='', stop_on_copy=False, revision_from=None, revision_to=None, changelist=False)
+### log_default(timestamp_from_dt=None, timestamp_to_dt=None, limit=None, rel_filepath=None, stop_on_copy=False, revision_from=None, revision_to=None, changelist=False, use_merge_history=False, search=None)
 
 Perform a log-listing that can be bounded by time or revision number and/or
 take a maximum-count.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -178,6 +178,17 @@ class TestCommonClient(unittest.TestCase):
             self.assertEquals(l.revision, 1)
             self.assertEquals(l.msg, 'Initial commit.')
 
+    def test_search(self):
+        with svn.test_support.temp_common() as (_, _, cc):
+            svn.test_support.populate_bigger_file_changes1()
+            svn.test_support.populate_bigger_file_change1()
+            actual = \
+                cc.log_default(search="Change file", revision_from=1, revision_to=2)
+            self.assertEqual(next(actual).revision, 2)
+            actual = \
+                cc.log_default(search="Initial", revision_from=1, revision_to=2)
+            self.assertEqual(next(actual).revision, 1)
+
     def test_cat(self):
         with svn.test_support.temp_common() as (_, _, cc):
             svn.test_support.populate_bigger_file_changes1()


### PR DESCRIPTION

This is a cleanup of  #120 to work with the 1.0 refactor. Mostly that involved rewriting the test case.

I was going to implement this myself, but saw there was an old PR, so I cleaned it up.