### PR TITLE
Add svn blame support

### DIFF
--- a/svn/resources/README.md
+++ b/svn/resources/README.md
@@ -25,6 +25,7 @@ Functions currently implemented:
 - update
 - cleanup
 - remove (i.e. rm, del, delete)
+- blame
 
 In addition, there is also an "admin" class (`svn.admin.Admin`) that provides a
 `create` method with which to create repositories.
@@ -266,6 +267,26 @@ for rel_path, e in l.list_recursive():
 # 'name': 'cc',
 # 'size': 0,
 # 'timestamp': datetime.datetime(2015, 4, 24, 3, 25, 13, 479212, tzinfo=tzutc())}
+```
+
+### blame(rel_filepath, revision=None)
+
+Blame specified file.
+
+```
+import pprint
+import svn.local
+
+lc = svn.local.LocalClient('/tmp/test_repo.co')
+
+for line_info in lc.blame("version.py"):
+    pprint.pprint(line_info)
+
+# {
+#    'line_number': 1,
+#    'commit_revision': 1222,
+#    'commit_author': 'codeskyblue',
+#    'commit_date': datetime.datetime(2018, 12, 20, 3, 25, 13, 479212, tzinfo=tzutc())}
 ```
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -208,6 +208,22 @@ class TestCommonClient(unittest.TestCase):
                 except:
                     pass
 
+    def test_blame(self):
+        with svn.test_support.temp_common() as (_, _, cc):
+            f = svn.test_support.populate_bigger_file_change1()
+            actual_answer = cc.blame(f, revision_to=2)
+            line1 = next(actual_answer)
+            for i in range(5):
+                # find the modified line
+                line6 = next(actual_answer)
+            line7 = next(actual_answer)
+            self.assertEqual(line1['line_number'], 1)
+            self.assertEqual(line1['commit_revision'], 1)
+            self.assertEqual(line1['commit_author'], line7['commit_author'])
+
+            self.assertEqual(line6['line_number'], 6)
+            self.assertEqual(line6['commit_revision'], 2)
+        
     def test_force__export(self):
         with svn.test_support.temp_common() as (_, _, cc):
             svn.test_support.populate_bigger_file_changes1()


### PR DESCRIPTION
Add new command and add test_blame test case.

This is a cleanup of #131 to work with the 1.0 refactor.