### PR TITLE
Adding 3 more functions to svn: propdel(), propget() and propset() and some smaller changes

### DIFF
--- a/dev/test2.py
+++ b/dev/test2.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python2.7
+
+from __future__ import print_function          # PY3
+
+import sys
+import os
+import os.path
+from pprint import pprint
+
+import svn
+from svn.exception import SvnException
+from svn.test_support import temp_repo, temp_checkout, populate_prop_files
+
+
+def cont(conttext='continue'):
+    try:
+        ctext=raw_input('  ENTER to %s:' % conttext)
+    except: # PY3
+        ctext=input('  ENTER to %s:' % conttext)
+    return ctext
+
+
+tempdir = os.environ.get('TEMPDIR',os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../temp')))
+
+dev_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, dev_path)
+
+import logging
+_logger = logging.getLogger()
+_logger.setLevel(logging.DEBUG)
+logging.getLogger('boto').setLevel(logging.INFO)
+
+ch = logging.StreamHandler()
+
+FMT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+formatter = logging.Formatter(FMT)
+ch.setFormatter(formatter)
+_logger.addHandler(ch)
+
+
+with temp_repo() as (repo_path, _):
+    print('Temp repo created at %s' % repo_path)
+    
+    with temp_checkout() as (wcpath, lc):
+        print('Working Copy created at %s' % wcpath)
+
+        populate_prop_files()
+        lc.commit("Second revision.")
+    
+        lc.propset('svn:mime-type','image/jpeg', rel_path='foo.jpg')
+        lc.propset('owner','sally', rel_path='foo.bar')
+        lc.propset('svn:ignore','foo.bak') # set on directory level
+
+        print('\n--- info for foo.bar ---')
+        pprint(lc.info('foo.bar'))
+        
+        pprint(lc.properties('foo.bar'))
+
+        print('\n--- info for foo.jpg ---')
+        pprint(lc.info('foo.jpg'))
+        pprint(lc.properties('foo.jpg'))
+
+        cont('before committing properties')
+        lc.commit('Committing properties')
+        lc.update()
+
+        print('\npropget for foo.jpg for svn:mime-type:', lc.propget('svn:mime-type', rel_path='foo.jpg'))
+
+        print('\n--- info for foo.bar after setting properties owner svn:ignore & commit---')
+        pprint(lc.info('foo.bar'))
+        cont()
+
+        lc.propset('svn:keywords','Author Date Rev', rel_path='foo.bar')
+
+        print('\n--- info and properties for foo.bar ---')
+        pprint(lc.info('foo.bar'))
+        pprint(lc.properties(rel_path='foo.bar'))
+
+        lc.propdel('owner', rel_path='foo.bar')
+
+        lc.commit('Committing after deleting property')
+        lc.update()
+        cont()
+
+        print('\nget property svn:ignore on . =', lc.propget('svn:ignore','.') )
+
+        print('--- properties for foo.bar HEAD ---')
+        pprint(lc.properties(rel_path='foo.bar'))
+
+        print('info on foo.bar')
+        pprint(lc.info(rel_path='foo.bar'))
+
+        print('\n--- properties for foo.bar rev 1 ---')
+        pprint(lc.properties(rel_path='foo.bar',revision=1))
+        print('properties for foo.bar rev 2:')
+        pprint(lc.properties(rel_path='foo.bar',revision=2))
+        print('\n--- properties for foo.bar rev 3 ---')
+        pprint(lc.properties(rel_path='foo.bar',revision=3))
+                
+#with self.assertRaises(Exception): # svn.exception.SvnException):
+#    lc.propget('owner', rel_path='foo.bar')
+# self.assertRaises(Exception, lc.propget,'owner', rel_path='foo.bar')
+
+        try:
+            lc.propget('owner', rel_path='foo.bar')
+        except SvnException as sx:
+            pass
+                        
+        print(lc.properties(rel_path='foo.bar'))
+        
+        cont('end of script')
+

--- a/svn/local.py
+++ b/svn/local.py
@@ -94,7 +94,7 @@ class LocalClient(svn.common.CommonClient):
                 revision = int(revision)
 
             yield _STATUS_ENTRY(
-                name=name,
+                name=svn.common.normpath2(name),
                 type_raw_name=change_type_raw,
                 type=change_type,
                 revision=revision

--- a/svn/test_support.py
+++ b/svn/test_support.py
@@ -12,7 +12,7 @@ import svn.admin
 
 @contextlib.contextmanager
 def temp_path():
-    original_wd = os.getcwd()
+    original_wd = os.path.normpath(os.getcwd())
 
     temp_path = None
     try:
@@ -37,7 +37,7 @@ def temp_repo():
         a = svn.admin.Admin()
         a.create('.')
 
-        rc = svn.remote.RemoteClient('file://{}'.format(repo_path))
+        rc = svn.remote.RemoteClient('file:///{}'.format(repo_path))
 
         yield repo_path, rc
 
@@ -47,10 +47,10 @@ def temp_checkout():
     current path.
     """
 
-    repo_path = os.getcwd()
+    repo_path = os.path.normpath(os.getcwd())
 
     with temp_path() as working_path:
-        rc = svn.remote.RemoteClient('file://{}'.format(repo_path))
+        rc = svn.remote.RemoteClient('file:///{}'.format(repo_path))
         rc.checkout('.')
 
         lc = svn.local.LocalClient(working_path)
@@ -80,7 +80,7 @@ def populate_bigger_file_changes1():
         "test_local_populate1() must be called with the working-directory " \
         "as the CWD."
 
-    working_path = os.getcwd()
+    working_path = os.path.normpath(os.getcwd())
     lc = svn.local.LocalClient(working_path)
 
     # Create a file that will not be committed.
@@ -150,7 +150,7 @@ def populate_bigger_file_change1():
         "test_local_populate1() must be called with the working-directory " \
         "as the CWD."
 
-    working_path = os.getcwd()
+    working_path = os.path.normpath(os.getcwd())
     lc = svn.local.LocalClient(working_path)
 
     # Create a file that will be committed and then changed a lot.
@@ -249,3 +249,36 @@ laborum."
     lc.update()
 
     return rel_filepath
+
+def populate_prop_files():
+    """Establish files for testing property changes"""
+
+    assert \
+        os.path.exists('.svn') is True, \
+        "populate_properties() must be called with the working-directory " \
+        "as the CWD."
+
+    working_path = os.path.normpath(os.getcwd())
+    lc = svn.local.LocalClient(working_path)
+
+    rel_filepath = 'foo.jpg'
+    with open(rel_filepath, 'w') as f:
+        pass
+    lc.add(rel_filepath)
+    
+    rel_filepath = 'foo.bar'
+    with open(rel_filepath, 'w') as f:
+        pass
+    lc.add(rel_filepath)
+
+    rel_filepath = 'foo.bak'
+    with open(rel_filepath, 'w') as f:
+        pass
+    
+
+    # Commit the new files.
+    lc.commit("Initial commit.")
+    
+    # Do an update to pick-up the changes from the commit.
+    lc.update()
+

--- a/svn/utility.py
+++ b/svn/utility.py
@@ -13,7 +13,7 @@ def get_client(url_or_path, *args, **kwargs):
 
 def get_common_for_cwd():
     path = os.getcwd()
-    uri = 'file://{}'.format(path)
+    uri = 'file:///{}'.format(path)
 
     cc = svn.common.CommonClient(uri, svn.constants.LT_URL)
     return cc

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -35,7 +35,7 @@ class TestAdmin(unittest.TestCase):
             a.create(temp_path)
 
             # Do a read.
-            rc = svn.remote.RemoteClient('file://' + temp_path)
+            rc = svn.remote.RemoteClient('file:///' + temp_path)
             info = rc.info()
             _LOGGER.debug("Info from new repository: [%s]", str(info))
         finally:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+import svn.common
 import svn.constants
 import svn.test_support
 
@@ -52,12 +53,13 @@ class TestLocalClient(unittest.TestCase):
                 status_all = list(status_all)
 
                 status_index = {
-                    s.name: s
+                    svn.common.normpath2(s.name): s
                     for s
                     in status_all
                 }
 
-                filepath = os.path.join(wc_path, 'new_file')
+                filepath = svn.common.normpath2(os.path.join(wc_path, 'new_file'))
+                
                 status = status_index[filepath]
 
                 self.assertEquals(status.type, svn.constants.ST_DELETED)


### PR DESCRIPTION
- added 3 svn functions in common.py: propdel, propget and propset

- added revision parameter in properties function

- added raw parameter for diff function

- added new test case for properties

-fixed unittest problems on Windows where path strings did not match due to different possible representations by adding a normpath2 function that unifies the paths on Windows

- updated README.md to cover changes and sorting function docs alphabetically

Please review the changes and if you are OK with it take it over. Thanks.