### PR TITLE
Fix Path Joins for Windows

### DIFF
--- a/svn/common.py
+++ b/svn/common.py
@@ -68,7 +68,7 @@ class CommonClient(svn.common_base.CommonBase):
 
         full_url_or_path = self.__url_or_path
         if rel_path is not None:
-            full_url_or_path += '/' + rel_path
+            full_url_or_path = self._pathjoin(full_url_or_path, rel_path)
         cmd += ['--xml', full_url_or_path]
 
         result = self.run_command(
@@ -144,7 +144,7 @@ class CommonClient(svn.common_base.CommonBase):
 
         full_url_or_path = self.__url_or_path
         if rel_path is not None:
-            full_url_or_path += '/' + rel_path
+            full_url_or_path = self._pathjoin(full_url_or_path, rel_path)
 
         result = self.run_command(
             'proplist',
@@ -176,7 +176,7 @@ class CommonClient(svn.common_base.CommonBase):
         cmd = []
         if revision is not None:
             cmd += ['-r', str(revision)]
-        cmd += [self.__url_or_path + '/' + rel_filepath]
+        cmd += [self._pathjoin(self.__url_or_path, rel_filepath)]
         return self.run_command('cat', cmd, return_binary=True)
 
     def log_default(self, timestamp_from_dt=None, timestamp_to_dt=None,
@@ -189,7 +189,7 @@ class CommonClient(svn.common_base.CommonBase):
 
         full_url_or_path = self.__url_or_path
         if rel_filepath is not None:
-            full_url_or_path += '/' + rel_filepath
+            self._pathjoin(full_url_or_path, rel_filepath)
 
         timestamp_from_phrase = ('{' + timestamp_from_dt.isoformat() + '}') \
             if timestamp_from_dt \
@@ -288,7 +288,7 @@ class CommonClient(svn.common_base.CommonBase):
     def list(self, extended=False, rel_path=None):
         full_url_or_path = self.__url_or_path
         if rel_path is not None:
-            full_url_or_path += '/' + rel_path
+            full_url_or_path = self._pathjoin(full_url_or_path, rel_path)
 
         if extended is False:
             for line in self.run_command(
@@ -347,6 +347,9 @@ class CommonClient(svn.common_base.CommonBase):
 
                 yield entry
 
+    def _pathjoin(self, *args):
+        return os.path.join(*args)
+
     def list_recursive(self, rel_path=None, yield_dirs=False,
                        path_filter_cb=None):
         q = [rel_path]
@@ -357,8 +360,8 @@ class CommonClient(svn.common_base.CommonBase):
             for entry in self.list(extended=True, rel_path=current_rel_path):
                 if entry['is_directory'] is True:
                     if current_rel_path is not None:
-                        next_rel_path = \
-                            os.path.join(current_rel_path, entry['name'])
+                        next_rel_path = self._pathjoin(
+                            current_rel_path, entry['name'])
                     else:
                         next_rel_path = entry['name']
 
@@ -385,7 +388,7 @@ class CommonClient(svn.common_base.CommonBase):
 
         full_url_or_path = self.__url_or_path
         if rel_path is not None:
-            full_url_or_path += '/' + rel_path
+            full_url_or_path = self._pathjoin(full_url_or_path, rel_path)
 
         arguments = [
             '--old', '{0}@{1}'.format(full_url_or_path, old),
@@ -418,7 +421,7 @@ class CommonClient(svn.common_base.CommonBase):
 
         full_url_or_path = self.__url_or_path
         if rel_path is not None:
-            full_url_or_path += '/' + rel_path
+            full_url_or_path = self._pathjoin(full_url_or_path, rel_path)
 
         arguments = [
             '--old', '{0}@{1}'.format(full_url_or_path, old),

--- a/svn/remote.py
+++ b/svn/remote.py
@@ -27,7 +27,7 @@ class RemoteClient(svn.common.CommonClient):
         if do_force is True:
             args.append('--force')
 
-        url = '{}/{}'.format(self.url, rel_path)
+        url = self._pathjoin(self.url, rel_path)
 
         args += [
             url
@@ -36,6 +36,19 @@ class RemoteClient(svn.common.CommonClient):
         self.run_command(
             'rm',
             args)
+
+    def _pathjoin(self, *args):
+        clean_args = []
+        for i, arg in enumerate(args):
+            if i != 0 and arg.startswith('/'):
+                arg = arg[1:]
+
+            if i != len(args) - 1 and arg.endswith('/'):
+                arg = arg[:-1]
+
+            clean_args.append(arg)
+
+        return '/'.join(clean_args)
 
     def __repr__(self):
         return '<SVN(REMOTE) %s>' % self.url

--- a/svn/remote.py
+++ b/svn/remote.py
@@ -1,3 +1,5 @@
+import posixpath
+
 import svn.constants
 import svn.common
 
@@ -38,17 +40,7 @@ class RemoteClient(svn.common.CommonClient):
             args)
 
     def _pathjoin(self, *args):
-        clean_args = []
-        for i, arg in enumerate(args):
-            if i != 0 and arg.startswith('/'):
-                arg = arg[1:]
-
-            if i != len(args) - 1 and arg.endswith('/'):
-                arg = arg[:-1]
-
-            clean_args.append(arg)
-
-        return '/'.join(clean_args)
+        return posixpath.join(*args)
 
     def __repr__(self):
         return '<SVN(REMOTE) %s>' % self.url


### PR DESCRIPTION
Fix for Issue #90: list_recursive does not support browsing svn with windows client

Created a dedicated method for handling path joins. Default behavior is to use `os.path.join` for native OS paths. `RemoteClient` overwrites the functionality to always uses forward slashes. All logic for joining paths has been replaced with calls to the new `_pathjoin` method.

A similar PR (#144) has been open for almost two years. It hasn't been accepted and I don't like how it completely redefines `list_recursive` for `RemoteClient`.