### PR TITLE
Support for "svn revert" and extension of "svn cleanup" be able to remove unversioned and untracked files.

### DIFF
--- a/svn/local.py
+++ b/svn/local.py
@@ -116,3 +116,20 @@ class LocalClient(svn.common.CommonClient):
         self.run_command(
             'rm',
             args)
+
+    def revert(self, rel_filepaths=["."], depth="empty"):
+        cmd = []
+        if(depth in (
+                    "empty", # only the target itself
+                     "files", # the target and any immediate file children thereof
+                     "immediates", # the target and any immediate children thereof
+                     "infinity" # the target and all of its descendants — full recursion
+                     )):
+            cmd += ["--depth", depth]
+            
+        cmd += rel_filepaths
+        self.run_command(
+            'revert',
+            cmd,
+            wd=self.path
+        )

--- a/svn/local.py
+++ b/svn/local.py
@@ -71,7 +71,7 @@ class LocalClient(svn.common.CommonClient):
 
         raw = self.run_command(
             'status',
-            ['--xml', path],
+            ['--no-ignore', '--xml', path],
             do_combine=True)
 
         root = xml.etree.ElementTree.fromstring(raw)

--- a/svn/resources/README.md
+++ b/svn/resources/README.md
@@ -25,6 +25,7 @@ Functions currently implemented:
 - update
 - cleanup
 - remove (i.e. rm, del, delete)
+- revert
 
 In addition, there is also an "admin" class (`svn.admin.Admin`) that provides a
 `create` method with which to create repositories.


### PR DESCRIPTION
- "svn revert" added
- "svn cleanup" can remove unversioned and ignored files and folders since svn version 1.9, such a functionality was added. Removal of files and folders is done manually to be independent of the svn commandline client.
- Added parameter "--no-ignore" to "svn status". Without this parameter ignored files aren't shown in all situations.