### PR TITLE
Retrieving the status of modified files

### DIFF
--- a/svn/local.py
+++ b/svn/local.py
@@ -76,7 +76,7 @@ class LocalClient(svn.common.CommonClient):
 
         root = xml.etree.ElementTree.fromstring(raw)
 
-        list_ = root.findall('target/entry')
+        list_ = root.findall('target/entry') + root.findall('changelist/entry')
         for entry in list_:
             entry_attr = entry.attrib
             name = entry_attr['path']


### PR DESCRIPTION
In the XML created by the svn status the modified files appear on a different category called "changelist". The current pySvn version was not capturing these files.