### PR TITLE
Getting status of all files

### DIFF
--- a/svn/local.py
+++ b/svn/local.py
@@ -76,7 +76,7 @@ class LocalClient(svn.common.CommonClient):
 
         root = xml.etree.ElementTree.fromstring(raw)
 
-        list_ = root.findall('target/entry')
+        list_ = root.findall('target/entry') + root.findall('changelist/entry')
         for entry in list_:
             entry_attr = entry.attrib
             name = entry_attr['path']

--- a/svn/local.py
+++ b/svn/local.py
@@ -71,7 +71,7 @@ class LocalClient(svn.common.CommonClient):
 
         raw = self.run_command(
             'status',
-            ['--xml', path],
+            ['--xml', path, '-v'],
             do_combine=True)
 
         root = xml.etree.ElementTree.fromstring(raw)


### PR DESCRIPTION
The current implementation of status returns only status of the unversioned files. The proposed modification includes the -v parameter that allows to recover information of other files and then parses the "changelist" elements on the returned XML.